### PR TITLE
Join resolved paths in theInternet.js rather than resolving them.

### DIFF
--- a/util/theInternet.js
+++ b/util/theInternet.js
@@ -36,7 +36,7 @@ const path = {
   },
   resolve: function (baseUrl, relativePath) {
     const parsed = new URL(baseUrl);
-    return parsed.origin + stdPath.resolve(parsed.pathname, relativePath);
+    return parsed.origin + stdPath.join(parsed.pathname, relativePath);
   },
   extname: function (url) {
     const parsed =  new URL(url);


### PR DESCRIPTION
The implementation of path.resolve in theInternet.js called
stdPath.resolve on a URL pathname and a relative path. The
resolved path would then be concatenated onto the URL origin.

Unfortunately, the nodejs implementation of path.resolve always
creates absolute paths. This meant that the following concatenation
would append the absolute path onto the URL origin resulting in an
invalid path.

This would cause the bookstore example to break on Windows. Specifically
`include
"https://s0tjdzrsha.execute-api.us-west-2.amazonaws.com/Sales/Sales.st"`
would have URL origin "https://s0tjdzrsha.execute-api.us-west-2.amazonaws.com",
pathname "/Sales", and relativePath "./client.js". The resolve step would
create absolute path "C:/Sales/client.js" and append it tot he URL
origin. The final result was
"https://s0tjdzrsha.execute-api.us-west-2.amazonaws.comC:/Sales/client.js".
This would cause issues later on in the AWS SDK.

This issue is fixed here by joining the paths instead of resolving them.
This solution has been tested on Windows 10.